### PR TITLE
Test node 8 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,12 +3,13 @@ version: '12.0.0#{build}'
 environment:
   matrix:
     - nodejs_version: "6"
+    - nodejs_version: "8"
 
 matrix:
   fast_finish: true
 
 install:
-  - ps: Install-Product node 6.11.1
+  - ps: Install-Product node $env:nodejs_version
   - npm install -g yarn
   - yarn install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ env:
   - CXX=g++-4.8 CI=true
 language: node_js
 node_js:
-  - "6.11.1"
+  - "6"
+  - "8"
 addons:
   apt:
     sources:


### PR DESCRIPTION
As announced in the README, this project will always officially support the most recent node.js LTS version.
Since version 8 becomes LTS soon (scheduled for [october 2017](https://github.com/nodejs/LTS#release-schedule1)), we should prepare this support up-front by executing the build and test tasks in the CI process.
