### PR TITLE
Rewrite utility scripts to use async/await whenever possible.

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -30,10 +30,16 @@ const started = withCoverage
   ? fs.emptyDir(paths.resolveApp("test-results"))
   : Promise.resolve();
 
-started
-  .then(() =>
-    compileTranslations("src/**/*.i18n.yml", "src/generated/translations.ts")
-  )
-  .then(() => {
-    jest.run(argv);
-  });
+async function test() {
+  const started = withCoverage
+    ? fs.emptyDir(paths.resolveApp("test-results"))
+    : Promise.resolve();
+  await started;
+  await compileTranslations(
+    "src/**/*.i18n.yml",
+    "src/generated/translations.ts"
+  );
+  return jest.run(argv);
+}
+
+test();


### PR DESCRIPTION
Simplifies the scripts a bit, and allows to get rid of a couple of parameters just being passed through the promise chaining.