### PR TITLE
Display file size differences in build output.

### DIFF
--- a/scripts/util/determineFileSizesBeforeBuild.js
+++ b/scripts/util/determineFileSizesBeforeBuild.js
@@ -1,0 +1,31 @@
+const fs = require("fs-extra");
+const glob = require("globby");
+
+const gzipSize = require("./gzipsize");
+const getRelativeChunkName = require("./getRelativeChunkName");
+const relevantSizeComparisonRegex = /\.(js|css|json|webmanifest)$/;
+
+function determineFileSizes(buildFolder) {
+  const globbed = glob.sync(["**/*.{js,css,json,webmanifest}"], {
+    cwd: buildFolder,
+    absolute: true
+  });
+
+  const sizes = globbed.reduce((result, fileName) => {
+    const contents = fs.readFileSync(fileName);
+    const key = getRelativeChunkName(buildFolder, fileName);
+    const originalSize = fs.statSync(fileName).size;
+    result[key] = {
+      original: originalSize,
+      gzip: gzipSize(contents)
+    };
+    return result;
+  }, {});
+
+  return { root: buildFolder, sizes };
+}
+
+module.exports = {
+  determineFileSizes,
+  relevantSizeComparisonRegex
+};

--- a/scripts/util/getRelativeChunkName.js
+++ b/scripts/util/getRelativeChunkName.js
@@ -1,0 +1,26 @@
+const path = require("path");
+
+function getRelativeChunkName(buildFolder, fileName) {
+  // TODO: We need to simplify this using path manipulations ...
+  // Enforce unix version to be able to properly handle everything else ...
+  const unixedBuildFolder = buildFolder.split(path.sep).join("/");
+
+  let unixedFileName = fileName.split(path.sep).join("/");
+
+  // Replacing by relative path is more stable, but not always usable regarding
+  // provided relative file names...
+  // In case `fileName` is an absolute path, using `path.relative` is favorable,
+  // since it also avoids problems with potentially leading path separators.
+  if (path.isAbsolute(unixedFileName)) {
+    unixedFileName = path.relative(unixedBuildFolder, unixedFileName);
+  } else {
+    unixedFileName = unixedFileName.replace(unixedBuildFolder, "");
+  }
+
+  return unixedFileName.replace(
+    /\/?(.*)(\.[0-9a-f]{8,})(\.chunk)?(\.js|\.css|\.json|\.webmanifest)/,
+    (match, p1, p2, p3, p4) => p1 + p4
+  );
+}
+
+module.exports = getRelativeChunkName;


### PR DESCRIPTION
Ported from my [vue-ts-playground](https://github.com/DorianGrey/vue-ts-playground) so it doesn't get lost when I migrate it to @vue/cli ;)

More serious: It's quite a likely feature to keep an overview of in- resp. decreasing file sizes. Still requires some testing, especially on windows. 

€dit: Works fine on windows now, still need a secondary on other system again, and the merge conflict resolved.